### PR TITLE
delete useless code for mi3/mi4

### DIFF
--- a/camera1/src/main/java/com/troop/freedcam/camera/parameters/manual/CCTManualClassHandler.java
+++ b/camera1/src/main/java/com/troop/freedcam/camera/parameters/manual/CCTManualClassHandler.java
@@ -34,7 +34,7 @@ public class CCTManualClassHandler
         {
             if (Build.VERSION.SDK_INT < 23)
             {
-                return new BaseCCTManual(parameters,WB_MANUAL,7500,2000,parametersHandler,100, WB_MODE_MANUAL_CCT);
+                return new BaseCCTManual(parameters,WB_MANUAL,7500,2000,parametersHandler,100, WB_MODE_MANUAL);
             }
             else
                 return new BaseCCTManual(parameters,WB_MANUAL,8000,2000,parametersHandler,100, WB_MODE_MANUAL_CCT);

--- a/camera1/src/main/java/com/troop/freedcam/camera/parameters/manual/CCTManualParameter.java
+++ b/camera1/src/main/java/com/troop/freedcam/camera/parameters/manual/CCTManualParameter.java
@@ -42,27 +42,7 @@ public class CCTManualParameter extends BaseManualParameter
         super(parameters, value, maxValue, MinValue, camParametersHandler,1);
 
         this.isSupported = false;
-
-        if (DeviceUtils.IS_DEVICE_ONEOF(DeviceUtils.MI3_4))
-        {
-            this.min = 2000;
-            if(!parameters.get("max-exposure-time").contains("."))
-                this.max = 7500;
-            else
-                this.max = 8500;
-            this.value = WB_MANUAL;
-            if(parameters.get("max-exposure-time").contains(".")) {
-                createStringArray(min, max, 100);
-                this.manualWbMode = WB_MODE_MANUAL;
-            }
-            else
-                this.manualWbMode = WB_MODE_MANUAL_CCT;
-            this.isSupported = true;
-                createStringArray(min, max, 100);
-
-
-        }
-        else if (DeviceUtils.IS(DeviceUtils.Devices.ZTE_ADV) ||DeviceUtils.IS(DeviceUtils.Devices.SonyM4_QC) || DeviceUtils.IS(DeviceUtils.Devices.LenovoK920))
+        if (DeviceUtils.IS(DeviceUtils.Devices.ZTE_ADV) ||DeviceUtils.IS(DeviceUtils.Devices.SonyM4_QC) || DeviceUtils.IS(DeviceUtils.Devices.LenovoK920))
         {
             this.min = 2000;
             this.max = 8000;


### PR DESCRIPTION
delete useless code from CCTManualParametrs because this params hardcode
set into CCTManualClassHandler and hope that fix cct on mi3/mi4 when sdk
< 23