### PR TITLE
improve portability

### DIFF
--- a/imageviewer/src/main/jni/internal/dcraw_common.cpp
+++ b/imageviewer/src/main/jni/internal/dcraw_common.cpp
@@ -22,6 +22,8 @@ it under the terms of the one of three licenses as you choose:
 */
 
 #include <math.h>
+#include <stdint.h>
+#include <sys/types.h>
 #include <swab.h>
 #include <android/log.h>
 #define LOG_TAG "DCRAW"

--- a/imageviewer/src/main/jni/swab.cpp
+++ b/imageviewer/src/main/jni/swab.cpp
@@ -1,5 +1,6 @@
 #include <stdint.h>
-#include <asm/byteorder.h>
+#include <sys/types.h>
+#include <endian.h>
 
 void swab(const void *from, void*to, ssize_t n)
 {
@@ -9,5 +10,5 @@ void swab(const void *from, void*to, ssize_t n)
 		return;
 
 	for (i = 0; i< (n/2)*2; i += 2)
-		*((uint16_t*)to+i) = __arch__swab16(*((uint16_t*)from+i));
+		*((uint16_t*)to+i) = __swap16(*((uint16_t*)from+i));
 }


### PR DESCRIPTION
I had to fix those to compile using Android Studio 2.1 on OS X.
Generally using kernel headers (asm/..) should be avoided.