### PR TITLE
Follow naming conventions of Sony Xperia C5

### DIFF
--- a/app/src/main/java/freed/cam/apis/camera1/parameters/DeviceSelector.java
+++ b/app/src/main/java/freed/cam/apis/camera1/parameters/DeviceSelector.java
@@ -42,7 +42,7 @@ import freed.cam.apis.camera1.parameters.device.mtk.Mlais_M52_Red_Note;
 import freed.cam.apis.camera1.parameters.device.mtk.Prestigio_Multipad_Color;
 import freed.cam.apis.camera1.parameters.device.mtk.Retro_MTK;
 import freed.cam.apis.camera1.parameters.device.mtk.Rome_X;
-import freed.cam.apis.camera1.parameters.device.mtk.SonyXperiaC4;
+import freed.cam.apis.camera1.parameters.device.mtk.Sony_C4;
 import freed.cam.apis.camera1.parameters.device.mtk.Sony_C5;
 import freed.cam.apis.camera1.parameters.device.mtk.Sony_M5_MTK;
 import freed.cam.apis.camera1.parameters.device.mtk.THL5000_MTK;
@@ -264,7 +264,7 @@ public class DeviceSelector {
                return new Sony_M4(cameraParameters,cameraUiWrapper);
 
             case SonyC4_MTK:
-                return new SonyXperiaC4(cameraParameters,cameraUiWrapper);
+               return new Sony_C4(cameraParameters,cameraUiWrapper);
             case SonyC5_MTK:
                return new Sony_C5(cameraParameters,cameraUiWrapper);
                 

--- a/app/src/main/java/freed/cam/apis/camera1/parameters/device/mtk/Sony_C4.java
+++ b/app/src/main/java/freed/cam/apis/camera1/parameters/device/mtk/Sony_C4.java
@@ -19,7 +19,7 @@
 
 package freed.cam.apis.camera1.parameters.device.mtk;
 
-import android.hardware.Camera;
+import android.hardware.Camera.Parameters;
 
 import freed.cam.apis.basecamera.CameraWrapperInterface;
 import freed.cam.apis.basecamera.parameters.modes.MatrixChooserParameter;
@@ -29,8 +29,10 @@ import freed.dng.DngProfile;
 /**
  * Created by troop on 23.08.2016.
  */
-public class SonyXperiaC4 extends BaseMTKDevice {
-    public SonyXperiaC4(Camera.Parameters parameters, CameraWrapperInterface cameraUiWrapper) {
+public class Sony_C4 extends BaseMTKDevice {
+    
+    
+    public Sony_C4(Parameters parameters, CameraWrapperInterface cameraUiWrapper) {
         super(parameters, cameraUiWrapper);
     }
 

--- a/app/src/main/res/values/devices.xml
+++ b/app/src/main/res/values/devices.xml
@@ -534,7 +534,9 @@
         <item>Aquaris M5</item>
     </string-array>
 
-    <string-array name="sony_c4">
+    <string-array name="SonyC4">
+        <item>E5333</item>
+        <item>E5343</item>
         <item>E5363</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Sony Xperia C4 and Sony Xperia C5 Ultra are both in the "Sony Xperia" series.
With reference to the codes for Sony Xperia C5, the class name has been modified to maintain a consistent format.
In addition, model numbers have been added. (Reference: [Click here](http://dl-developer.sonymobile.com/documentation/whitepapers/Xperia_C4_Dual_E5333_E5343_E5363_WP_4.pdf))