### PR TITLE
Enable opcode for Sony C4, Add Sony C4 to DngSupportedDevices.java

### DIFF
--- a/app/src/main/java/freed/cam/apis/camera1/parameters/device/mtk/Sony_C4.java
+++ b/app/src/main/java/freed/cam/apis/camera1/parameters/device/mtk/Sony_C4.java
@@ -52,4 +52,9 @@ public class Sony_C4 extends BaseMTKDevice {
         }
         return null;
     }
+    
+    @Override
+    public AbstractModeParameter getOpCodeParameter() {
+        return new OpCodeParameter(cameraUiWrapper.GetAppSettingsManager());
+    }    
 }

--- a/app/src/main/java/freed/dng/DngSupportedDevices.java
+++ b/app/src/main/java/freed/dng/DngSupportedDevices.java
@@ -236,11 +236,11 @@ public class DngSupportedDevices
                     default:
                         return new DngProfile(64, 4192, 3104, DngProfile.Plain, DngProfile.RGGB, 0,matrixChooser.GetCustomMatrix(MatrixChooserParameter.NEXUS6));
                 }
-            case 26257920://SOny C5 probable imx 214 rggb
+            case 26257920://Sony C4,C5 probably IMX214 rggb
                 switch (device)
                 {
+                    case SonyC4_MTK:
                     case SonyC5_MTK:
-                        return new DngProfile(64, 4206, 3120, DngProfile.Plain,DngProfile.RGGB, 0, matrixChooser.GetCustomMatrix(MatrixChooserParameter.IMX214));
                     case Jiayu_S3:
                         return new DngProfile(64, 4208, 3120, DngProfile.Plain, DngProfile.RGGB, 0, matrixChooser.GetCustomMatrix(MatrixChooserParameter.IMX214));
                 }


### PR DESCRIPTION
Changes:
1. Enabled opcode for Sony C4
2. Added Sony C4 to `DngSupportedDevices.java`

Remarks:
1. Sony C4 and Sony C5 are probably using IMX214. Reference: [Wikipedia's list](https://en.wikipedia.org/wiki/Exmor#List_of_Exmor_RS_sensors)
2. Originally the code in `DngSupportedDevices.java` for Sony C5 uses the value 4206. However in `Sony_C5.java`, 4208 is used. In addition, the file size 26257920 is obtained by 4208x3120 (dimensions) x 16 (Color depth: 16 bit) / 8 (convert bits to bytes). Therefore I guess 4208 is the correct value.

Sorry that because I do not have access to a fast computer (i.e. with a decent CPU), and Android Studio takes a long time to download the files, I cannot compile and test the app prior to creating this pull request.